### PR TITLE
Monthly crud improvement

### DIFF
--- a/app/assets/javascripts/schedule.js
+++ b/app/assets/javascripts/schedule.js
@@ -1647,16 +1647,24 @@ function populateEvents()
 			$(".sch-month-evnt").draggable(
 			{
 				containment: "#sch-holder",
-				snap: ".evt-snap",
-				snapMode: "inner",
 				appendTo: "body",
 				cancel: "img",
 				revertDuration: 0,
-				opacity: 0.7,
 				distance: 10,
 				scroll: false,
 				revert: "invalid",
 				stack: ".sch-month-evnt",
+				helper: function()
+				{
+					$copy = $(this).clone(); // copy the monthly event
+
+					$(this).css('opacity', '0'); // hide the original
+
+					$copy.css('width', $(this).css('width')); // set the copy's width (since % don't work without inheritance)
+					$copy.css('z-index', '10'); // and increase the copy's z-index
+
+					return $copy;
+				},
 				stop: function() {
 					if($(this).attr('data-date')) // check for a data-date from being over a date tile
 					{

--- a/app/assets/stylesheets/schedule.scss
+++ b/app/assets/stylesheets/schedule.scss
@@ -782,52 +782,6 @@ input[readonly="readonly"]
 			.inner { background: rgba(255, 255, 151, 0.5); }
 		}
 	}
-	.sch-month-evnt
-	{
-		margin: 0px 2px 4px 2px;
-		position: relative;
-		color: grey;
-		border-left: solid 3px;
-		padding-left: 5px;
-		background: white;
-		text-align: left;
-		line-height: 1.1;
-		font-size: 14px;
-		transition: box-shadow 0.3s;
-		cursor: pointer;
-
-		.time
-		{
-			font-size: 10px;
-			color: grey;
-		}
-		.close
-		{
-			opacity: 0;
-			background-image: image-url("close-wht.png");
-			background-repeat: no-repeat;
-			background-size: 90%;
-			background-position: center;
-			background-color: rgba(54, 54, 54, 0.5);
-			position: absolute;
-			border-radius: 100px;
-			cursor: pointer;
-			top: 2px;
-			right: 2px;
-			width: 15px;
-			height: 15px;
-			transition: background-color 0.3s, opacity 0.3s;
-
-			&:hover { background-color: rgb(54, 54, 54); }
-		}
-		/* Show close button when hovering over an event, but not when dragging it */
-		&:not(.ui-draggable-dragging):hover
-		{
-			box-shadow: 0px 0px 5px black;
-
-			.close { opacity: 1; }
-		}
-	}
 	.day-of-month
 	{
 		font-size: 16px;
@@ -848,6 +802,58 @@ input[readonly="readonly"]
 		.day-of-month { font-weight: bold; }
 	}
 }
+
+.sch-month-evnt
+{
+	margin: 0px 2px 4px 2px;
+	position: relative;
+	color: grey;
+	border-left: solid 3px;
+	padding-left: 5px;
+	background: white;
+	text-align: left;
+	line-height: 1.1;
+	font-size: 14px;
+	transition: box-shadow 0.3s;
+	cursor: pointer;
+
+	.time
+	{
+		font-size: 10px;
+		color: grey;
+	}
+	.close
+	{
+		opacity: 0;
+		background-image: image-url("close-wht.png");
+		background-repeat: no-repeat;
+		background-size: 90%;
+		background-position: center;
+		background-color: rgba(54, 54, 54, 0.5);
+		position: absolute;
+		border-radius: 100px;
+		cursor: pointer;
+		top: 2px;
+		right: 2px;
+		width: 15px;
+		height: 15px;
+		transition: background-color 0.3s, opacity 0.3s;
+
+		&:hover { background-color: rgb(54, 54, 54); }
+	}
+	/* Show close button when hovering over an event, but not when dragging it */
+	&:not(.ui-draggable-dragging):hover
+	{
+		box-shadow: 0px 0px 5px black;
+
+		.close { opacity: 1; }
+	}
+	&.ui-draggable-dragging
+	{
+		box-shadow: 0px 0px 5px black;
+	}
+}
+
 /* On hover show all events */
 .sch-day-tile:hover
 {


### PR DESCRIPTION
I've worked on making the monthly view more useful so that it is a place you can actually make a schedule, rather than just a way to view the schedule you made in weekly view.

In particular, you can now:

- Drag categories to the monthly view to make events
  <img src="https://cloud.githubusercontent.com/assets/3187531/24429198/a00a212a-13d6-11e7-8e38-2421d5206514.png" width="100%">
- Drag events in the monthly view to move them
![screenshot from 2017-03-28 16-30-02](https://cloud.githubusercontent.com/assets/3187531/24429278/f8141830-13d6-11e7-8fc6-646847aefab3.png)
- Delete events in the monthly view
![screenshot from 2017-03-28 16-30-40](https://cloud.githubusercontent.com/assets/3187531/24429196/a0099d9a-13d6-11e7-9cc1-9b811fe50e4e.png)


Try it out on the [test app](https://carpe-test.herokuapp.com/) and see what you think.

I'd like people to review the styling and design of this, my code quality, and anything else you can think of.