### PR TITLE
Made Rake Test Output Test Results

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,7 +7,7 @@ end
 
 # Add Minitest reporting
 require "minitest/reporters"
-Minitest::Reporters.use! Minitest::Reporters::HtmlReporter.new(:reports_dir => "public/html_reports")
+Minitest::Reporters.use! [Minitest::Reporters::HtmlReporter.new(:reports_dir => "public/html_reports"), Minitest::Reporters::DefaultReporter.new]
 
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)


### PR DESCRIPTION
Matt and I realized that Travis is not useful when only the HTML Reporter is running, since running `rake test` does not output test results to console, but only to the HTML report files. Adding the default reporter on top of the HTML reporting makes it so running `rake test` prints the usual test outputs and also outputs to HTML, which covers all use cases.