### PR TITLE
Fixed Blank Search 500 Error

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -85,6 +85,8 @@ class ApplicationController < ActionController::Base
       }
 
       render :json => user_map # + group_map
+    else
+      render :json => {} # render nothing to prevent a no template error
     end
   end
 


### PR DESCRIPTION
If a search is done with just whitespace characters (as a blank search won't even be passed to the backend), the search returns a 500 error due to the only render being in a check for valid characters. This resolves that issue by simply returning an empty JSON hash in that condition.

This was discovered via Papertrail, which logged this error:

```
Processing by ApplicationController#search_core as JSON 
  Parameters: {"q"=>"     "} 
Completed 500 Internal Server Error in 5ms 
ActionView::MissingTemplate (Missing template application/search_core with {:locale=>[:en], :formats=>[:json], :variants=>[], :handlers=>[:erb, :builder, :raw, :ruby, :coffee, :jbuilder]}. Searched in: 
  * "/app/app/views" 
  * "/app/vendor/bundle/ruby/2.3.0/gems/devise-4.3.0/app/views" 
): 
```

Local testing confirmed this issue, and confirmed that the work on this PR remedies it.