### PR TITLE
fixed breaks not showing up in reverse cronological order

### DIFF
--- a/app/assets/javascripts/schedule.js
+++ b/app/assets/javascripts/schedule.js
@@ -1911,6 +1911,7 @@ function setupBreakAddOverlay(managing)
 		}
 
 
+		// Prepend each break so that the most recently created break created comes first in the list
 		$("#break-cont").prepend("<div class='break-elem " +  classAdd +"' data-id='" + id + "' >"
 				+ checkbox
 				+ breakInstance.name + " | " + dateToString(breakInstance.startDate) + " | " + dateToString(breakInstance.endDate)


### PR DESCRIPTION
https://github.com/vkoves/carpe/issues/112

fixed breaks not showing up in reverse cronological order