### PR TITLE
Fixed new break being added to scheduleItem before the break exists

### DIFF
--- a/app/assets/javascripts/schedule.js
+++ b/app/assets/javascripts/schedule.js
@@ -2142,17 +2142,26 @@ function deleteEvent(event, elem)
 			createBreak(breakTitle, breakDateString, breakDateString, function(newBreak)
 			{
 				newBreakId = newBreak.id;
+				applyNewBreak(); // apply new break after server responds with our break ID
 			});
 		}
+		else
+		{
+			applyNewBreak();
+		}
 
-		// Now that we have a break that will make this event be skipped, add it and update UI accordingly
-		schItem.breaks.push(newBreakId);
+		// Add the new break to the schedule item and repopulate the schedule to apply it
+		function applyNewBreak()
+		{
+			// Now that we have a break that will make this event be skipped, add it and update UI accordingly
+			schItem.breaks.push(newBreakId);
 
-		updatedEvents(schItem.tempId, "breaks"); //mark that the events changed to enable saving
+			updatedEvents(schItem.tempId, "breaks"); //mark that the events changed to enable saving
 
-		repopulateEvents();
+			repopulateEvents();
 
-		UIManager.slideOutHideOverlay("#evnt-delete.overlay-box");
+			UIManager.slideOutHideOverlay("#evnt-delete.overlay-box");
+		}
 	}
 
 	// Deletes the associated event object, like the old delete. This gets rid of all items repeating


### PR DESCRIPTION
This should resolve #196. In essence, when deleting a single occurence, the scheduler would try and apply the ID of the new break to the schedule item - but it didn't exist! This meant the `scheduleItem.breaks` became `[undefined]` (an array of a single element, `undefined`) if the item had no other breaks, and no matter what this broke the core scheduling render loop. Since adding a break calls `repopulateEvents()` this ended up visually deleting all events.

My fix is to apply the new break after the server has given us an ID (and we know for sure the break was made), if the break does not exist. 