### PR TITLE
Updated .gitignore to ignore node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ jsdoc-out
 # Ignore CodeceptJS error output and HTML output
 spec/codeceptjs/output/
 public/codeceptjs_out
+
+# Ignore node modules
+node_modules/


### PR DESCRIPTION
This is because for JS testing and such we have NPM packages that we use, which get written to the node_modules in the Carpe folder.