### PR TITLE
Added Release and Testing Guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,8 +112,8 @@ Deploying Carpe should be done carefully and in a planned fashion, as it is a li
 - All releases must have been frozen for 48 hours prior to the release time - For the 48 hours before a release, QA should be carried out with **absolutely no changes** made to the release candidate. This release lock time allows for a final set of testing that can verify that all functionality is working properly without any risk of new changes breaking it. If critical bugs are found that need to delay deployment, the 48 hour release candidate lock must begin anew when the fix is applied to the release branch, and the full deployment QA process must be rerun.
 - Before a deployment (but after making a release candidate), go through all development issues and change them to be labelled release-candidate instead of development, as they are now on the release candidate branch.
 - After deployment:
- - Remove the release-candidate label from any remaining issues, as they are now on production if they have not been resolved.
- - Open a pull request from `master` into `dev` to get fixes applied to the release-candidate into the development environment.
+	 - Remove the release-candidate label from any remaining issues, as they are now on production if they have not been resolved.
+	 - Open a pull request from `master` into `dev` to get fixes applied to the release-candidate into the development environment.
 
 # Testing Carpe
 


### PR DESCRIPTION
Following our [Carpe Fall 2017 Release Postmortem](https://docs.google.com/document/d/1bRBFuwGjmmeolIkcjMxfMfQF9ccJzRt7CPpYXXkPuH8/edit#) I have added a set of manual tests that must be run before a release, have added an official set of guidelines for releasing Carpe, and have added new labels for bug priorities (low, medium, high, and critical) and for what version of Carpe an issue was found on. For the latter, the labels release-candidate and development were created, as issues labelled with neither should be assumed to be in production until confirmed otherwise.

Please read through these changes and give me any feedback you might have on these guidelines, as we will be following them from when this pull request is merged.