### PR TITLE
Added cookie warning for 422 error

### DIFF
--- a/public/422.html
+++ b/public/422.html
@@ -59,9 +59,8 @@
   <div class="dialog">
     <div>
       <h1>The change you wanted was rejected.</h1>
-      <p>Maybe you tried to change something you didn't have access to.</p>
     </div>
-    <p>If you are the application owner check the logs for more information.</p>
+    <p>If you have cookies disabled, please enable them to log in properly.</p>
   </div>
 </body>
 </html>


### PR DESCRIPTION
Addressing issue #4, I added a more interpretable message to our 422 error page, which displays upon cookie failure.