### PR TITLE
Slight copy fix on homepage

### DIFF
--- a/app/views/home/home.html.erb
+++ b/app/views/home/home.html.erb
@@ -3,7 +3,7 @@
 
 <div id="home-sl1">
 	<h1>Scheduling for the modern age.</h1>
-	<h2>Meet Carpe. It's a social, powerful planning tool for the modern world.</h2>
+	<h2>Meet Carpe. It's a social, powerful planning tool for today's world.</h2>
 	<div class="alphawarn">You can try out Carpe in our open Alpha.</div>
 
 	<%= link_to_block "Sign Up", new_user_registration_path(:refer => "wlcm-tp"), :class => "home-signup-btn" %>


### PR DESCRIPTION
Removed and replaced redundant use of the word "modern" on the homepage.