### PR TITLE
Repair Notification div blocking text selection on page

### DIFF
--- a/app/assets/stylesheets/carpe.scss
+++ b/app/assets/stylesheets/carpe.scss
@@ -426,12 +426,12 @@ input.danger:hover
 .alert-holder
 {
 	position: absolute;
-	top: 55px;
+	top: 60px;
 	z-index: 100;
-	height: 20px;
+	min-height: 20px;
 	text-align: center;
 	display: inline-block;
-	left: 50%; 
+	left: 50%;
 	transform: translateX(-50%);
 }
 .notice, .alert
@@ -441,7 +441,6 @@ input.danger:hover
   padding: 5px 5px 5px 40px;
   border-radius: 5px;
   position: relative;
-  top: 5px;
   font-weight: 500;
 
   img


### PR DESCRIPTION
Resolves #259. Specifically, the notification panel had an issue where the previous implementation centered it using a full-width div. Since one cannot click through that div given notification's high z-index, items that came up in the search bar (or any panel for that matter that happened to have elements in the same y range of the notification panel) would not be clickable. This was especially problematic for links, where results would be cancelled since the pointer was treated as on the notifications div instead when that notifications div padding was not visible before here.

## Description

At first, as identified with @Watercycle in a pair session, we saw that the div for notifications was taking up the entire page. We first aimed to fix this by removing `width: 100%` and using left/right properties instead, but this would essentially emulate the same issue. Instead, we devised that the button should be centered by assuming the left starts at 50%, and then we should shift the element by half of the width given here. To do this, a transform in the X direction was added that tracks 50% of the div width and shifts by this amount. 

These are the only changes made by the pull request, and despite concurrent work on the issue, is detached from the work at #257. This should not break any other work, as the change was constrained to only this action panel, but more thorough testing with other types of alerts (i.e. user profile) is highly recommended before approval. 

As a visual aid, here was the previous layout of the old div: 

![image](https://user-images.githubusercontent.com/3650044/38452027-8d8f8ade-3a00-11e8-948b-c3e14e30a95e.png)

...and here is what is obtained now:

![image](https://user-images.githubusercontent.com/3650044/38452033-b402a250-3a00-11e8-99d9-b28d8c67a238.png)



## Type of Pull Request
Based on the [contributor's guide][contrib-guide], this PR is of type:

- [x] Development (`feature-branch` -> `dev`)
- [ ] Hotfix (`hotfix-branch` -> `master`)
- [ ] Release (`release-branch` -> `master`)
- [ ] Other

## Requestor Checklist
**Requestor**: Put an `x` in all that apply. You can check boxes after the PR has been made.

**Reviewer**: If you see an item that is not checked that you believe should be, comment on that as part of your review.

- [ ] I have written tests to ensure that my changes work and handle edge cases
- [ ] I have documented my changes thoroughly (using [JSDoc][jsdoc] in Javascript)
- [x] I have linked to any relevant GitHub issues to this PR including [marking issues][gh-marking-issues] that this PR resolves
- [x] I have requested reviews from at least as many users as required for the type of PR (2 or 3)
- [ ] I have added this pull request to the relevant quarterly milestone
- [x] I have tested my changes locally and verified that they resolve the issues they are supposed to
- [ ] **(Hotfixes & Deployments)** I have assigned a user to this PR to handle merging and deployment
- [ ] **(Hotfixes & Deployments)** I have pushed up my changes to [Carpe test][carpe-test] for review and tested my changes there

## How This Has Been Tested
This was tested with alerts that were generated from sign-in by Google account, sign-in from normal account, and sign out, as well as any other activity that used the normal "green" alert activity. _Note that this means error states, like they would appear in the Edit Profile section, have not been tested yet._ The fix was tested across Google Chrome, Microsoft Edge, and Mozilla Firefox, all at 1920x1080 resolution. Internet Explorer 11 was not fully tested due to limitations with JS load (which I could swear there was an issue for, yet it is either closed or my search queries are not specific enough here). 





[contrib-guide]: CONTRIBUTING.md
[contrib-guide-prs]: CONTRIBUTING.md#creating-pull-requests
[contrib-guide-deploying]: CONTRIBUTING.md#deploying-carpe
[gh-marking-issues]: https://help.github.com/articles/closing-issues-using-keywords/
[carpe-test]: https://carpe-test.herokuapp.com/
[jsdoc]: http://usejsdoc.org/about-getting-started.html
