### PR TITLE
Repaired header to expand width by percentage

### DIFF
--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -10,7 +10,7 @@ body {
 .header-main
 {
 	position: fixed;
-	width: 100vw;
+	width: 100%;
 	height: $header-height-desktop;
 	top: 0px;
 	background: rgb(242, 242, 242);


### PR DESCRIPTION
With the most recent changes pulled into dev that modified the home page, we set the header based on view-widths. This works nicely for some cases where scrollbars do not exist immediately on the page (i.e. mobile devices), but caused header contents to still draw under the scrollbar on desktop environments (at higher resolutions). As a result, this pull request brings back the 100% width as this would universally ensure the same width for the header on all devices (while making sure no objects are blocked or trying to draw too far, especially when we have no horizontal overflow). 

Co-authored-by Matthew Spero (watercycle@email.com).

## Description
Resolves #293.
 
After finding the issue, we noticed that view-widths should take up the entire screen area that is designated, including scrollbars. By using inspector and testing with views across devices, we noticed that percent values still worked well. 

As noted earlier, the only change that this brings in is the calculation mechanism for how wide the header is. This should not break any other work, but if it does, it may cause some layout or positional errors in pages where contents would overflow. 

Here is a result of what the changes now look like, which should be compared to the image as found in the issue listed earlier. 

![image](https://user-images.githubusercontent.com/3650044/43672736-f711c590-9779-11e8-8613-cbff95fb0cd2.png)


## Type of Pull Request
Based on the [contributor's guide][contrib-guide], this PR is of type:

- [X] Development (`feature-branch` -> `dev`)
- [ ] Hotfix (`hotfix-branch` -> `master`)
- [ ] Release (`release-branch` -> `master`)
- [ ] Other

## Requestor Checklist
**Requestor**: Put an `x` in all that apply. You can check boxes after the PR has been made.

**Reviewer**: If you see an item that is not checked that you believe should be, comment on that as part of your review.

- [ ] _Code Quality:_ I have written tests to ensure that my changes work and handle edge cases
- [ ] _Code Quality:_ I have documented my changes thoroughly (using [JSDoc][jsdoc] in Javascript)
- [X] _Process:_ I have linked to any relevant GitHub issues to this PR including [marking issues][gh-marking-issues] that this PR resolves
- [X] _Process:_ I have requested reviews from at least as many users as required for the type of PR (2 or 3)
- [X] _Process:_ I have added this pull request to the relevant quarterly milestone
- [X] _Process:_ I have tested my changes locally and verified that they resolve the issues they are supposed to
- [ ] _Process:_ **(Hotfixes & Deployments)** I have assigned a user to this PR to handle merging and deployment
- [ ] _Process:_ **(Hotfixes & Deployments)** I have pushed up my changes to [Carpe test][carpe-test] for review and tested my changes there

## How This Has Been Tested
All tests happened locally through a run-through of the site, where the user was first unauthenticated. Screengrabs and comparison via various ruler tools was then used, alongside Chrome's own reporting of how the div is padded. Testing then followed by going to the unauthenticated home page in Edge and confirming similar positioning as seen in Chrome here.





[contrib-guide]: CONTRIBUTING.md
[contrib-guide-prs]: CONTRIBUTING.md#creating-pull-requests
[contrib-guide-deploying]: CONTRIBUTING.md#deploying-carpe
[gh-marking-issues]: https://help.github.com/articles/closing-issues-using-keywords/
[carpe-test]: https://carpe-test.herokuapp.com/
[jsdoc]: http://usejsdoc.org/about-getting-started.html
