### PR TITLE
Ci Chrome Install Fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,7 @@ jobs:
           name: Install Chrome
           command: |
             wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+            sudo apt-get install libappindicator3-1
             sudo dpkg -i google-chrome-stable_current_amd64.deb
       - run:
           name: Install Node Packages


### PR DESCRIPTION
As can be seen [here](https://circleci.com/gh/vkoves/carpe/248), Chrome is failing to install on CircleCI. I don't actually know why, but a quick solution seems to be just switching the install method.

## Type of Pull Request
Based on the [contributor's guide][contrib-guide], this PR is of type:

- [x] Development (`feature-branch` -> `dev`)
- [ ] Hotfix (`hotfix-branch` -> `master`)
- [ ] Release (`release-branch` -> `master`)
- [ ] Other

## Requestor Checklist
**Requestor**: Put an `x` in all that apply. You can check boxes after the PR has been made.

**Reviewer**: If you see an item that is not checked that you believe should be, comment on that as part of your review.

- [ ] Code Quality: I have written tests to ensure that my changes work and handle edge cases
- [ ] Code Quality: I have documented my changes thoroughly (using [JSDoc][jsdoc] in Javascript)
- [ ] Process: I have linked relevant issues, [marking issues][gh-marking-issues] that this PR resolves
- [x] Process: I have requested at least as many reviews required for this PR type (2 or 3)
- [x] Process: I have added this PR to the relevant quarterly milestone
- [ ] Process: I have tested this PR locally and verified it does what it should

## How This Has Been Tested
Checking that this branch passes on the CircleCI website.