### PR TITLE
Made event invite emails show placeholder text with optional fields

### DIFF
--- a/app/views/user_notifier/event_invite_email.html.erb
+++ b/app/views/user_notifier/event_invite_email.html.erb
@@ -27,12 +27,20 @@
 
         <p>
           <strong>Description: </strong>
-          <%= @event.description %>
+          <% if @event.description.empty? %>
+            <em>Not specified</em>
+          <% else %>
+            <%= @event.description %>
+          <% end %>
         </p>
 
         <p>
           <strong>Location: </strong>
-          <%= @event.location %>
+          <% if @event.location.empty? %>
+            <em>Not specified</em>
+          <% else %>
+            <%= @event.location %>
+          <% end %>
         </p>
 
         <p>


### PR DESCRIPTION
## Description

This resolves #417, where event invite emails shows nothing if fields are empty. Here's a screenshot of the preview email:

![Screenshot from 2019-04-09 20-41-05](https://user-images.githubusercontent.com/3187531/55845625-419a2d80-5b08-11e9-894e-e10c9055280e.png)

## Type of Pull Request
Based on the [contributor's guide][contrib-guide], this PR is of type:

- [ ] Development (`feature-branch` -> `dev`)
- [ ] Hotfix (`hotfix-branch` -> `master`)
- [ ] Release (`release-branch` -> `master`)
- [x] Other

## Requestor Checklist
**Requestor**: Put an `x` in all that apply. You can check boxes after the PR has been made.

**Reviewer**: If you see an item that is not checked that you believe should be, comment on that as part of your review.

- [ ] Code Quality: I have written tests to ensure that my changes work and handle edge cases
- [ ] Code Quality: I have documented my changes thoroughly (using [JSDoc][jsdoc] in Javascript)
- [x] Process: I have linked relevant issues, [marking issues][gh-marking-issues] that this PR resolves
- [x] Process: I have requested at least as many reviews required for this PR type (2 or 3)
- [x] Process: I have added this PR to the relevant quarterly milestone
- [x] Process: I have tested this PR locally and verified it does what it should

## How This Has Been Tested

Tested manually in the email previews.


[contrib-guide]: CONTRIBUTING.md
[contrib-guide-prs]: CONTRIBUTING.md#creating-pull-requests
[contrib-guide-deploying]: CONTRIBUTING.md#deploying-carpe
[gh-marking-issues]: https://help.github.com/articles/closing-issues-using-keywords/
[carpe-test]: https://carpe-test.herokuapp.com/
[jsdoc]: http://usejsdoc.org/about-getting-started.html
