### PR TITLE
Fix Event Color Not Changing On Monthly View

### DIFF
--- a/app/assets/javascripts/schedule/schedule.js
+++ b/app/assets/javascripts/schedule/schedule.js
@@ -1496,7 +1496,7 @@ function editEvent(elem) {
       var val = $(this).val();
       currEvent.setCategory(val);
       // changes the background color of event and changes all references to past events
-      const categoryColor = categories[currEvent.categoryId].color
+      const categoryColor = categories[currEvent.categoryId].color;
 
       $('.sch-evnt[evnt-temp-id=\'' + evntId + '\'], #overlay-color-bar').css('background-color', categoryColor);
       $('.sch-evnt[evnt-temp-id=\'' + evntId + '\']').attr('data-id', val);


### PR DESCRIPTION
Currently, monthly events tiles do not update their category color when you change an event's category through the overlay panel category selector. This PR fixes that.

I'm not sure if there was a reason why, but `temp-evnt-id` was only being tracked on weekly events. The other part to this PR was just adding the appropriate selector to update the monthly event tiles.

Issue described here: https://github.com/vkoves/carpe/pull/414#pullrequestreview-232579738

## Type of Pull Request
Based on the [contributor's guide][contrib-guide], this PR is of type:

- [ ] Development (`feature-branch` -> `dev`)
- [ ] Hotfix (`hotfix-branch` -> `master`)
- [ ] Release (`release-branch` -> `master`)
- [x] Other

## Requestor Checklist
**Requestor**: Put an `x` in all that apply. You can check boxes after the PR has been made.

**Reviewer**: If you see an item that is not checked that you believe should be, comment on that as part of your review.

- [ ] Code Quality: I have written tests to ensure that my changes work and handle edge cases
- [ ] Code Quality: I have documented my changes thoroughly (using [JSDoc][jsdoc] in Javascript)
- [x] Process: I have linked relevant issues, [marking issues][gh-marking-issues] that this PR resolves
- [x] Process: I have requested at least as many reviews required for this PR type (2 or 3)
- [x] Process: I have added this PR to the relevant quarterly milestone
- [x] Process: I have tested this PR locally and verified it does what it should

## How This Has Been Tested
Tested locally.

1) Create two categories with different colors
2) Place an event on the schedule
3) Switch to monthly view
4) Click (edit) the event
5) Change the category