### PR TITLE
Remove Migration That Prevented Deploy

### DIFF
--- a/db/migrate/20190415214015_remove_default_event_invite_category_foreign_key.rb
+++ b/db/migrate/20190415214015_remove_default_event_invite_category_foreign_key.rb
@@ -1,5 +1,0 @@
-class RemoveDefaultEventInviteCategoryForeignKey < ActiveRecord::Migration[5.2]
-  def change
-    # remove_foreign_key :users, :default_event_invite_category_id
-  end
-end


### PR DESCRIPTION
## Description

So there were a variety of issues with migrations running against the prod database, due to event invites having foreign key constraints and that causing problems with renames and such. I was able to fix some of them by dropping the old constraints, but in 3a130d2, I commented this migration out since it just was not needed on prod and thus failed. The foreign key being removed just didn't exist.

@Watercycle - I wanted to get your feedback on this, and see if it might be time for us to squash our migrations to get rid of old nonsense and back and forths we had.

This PR should go into the release branch, which should then go into `master` via a hotfix and `develop` via PR #429.

## Type of Pull Request
Based on the [contributor's guide][contrib-guide], this PR is of type:

- [ ] Development (`feature-branch` -> `dev`)
- [ ] Hotfix (`hotfix-branch` -> `master`)
- [ ] Release (`release-branch` -> `master`)
- [x] Other

## Requestor Checklist
**Requestor**: Put an `x` in all that apply. You can check boxes after the PR has been made.

**Reviewer**: If you see an item that is not checked that you believe should be, comment on that as part of your review.

- [ ] Code Quality: I have written tests to ensure that my changes work and handle edge cases
- [ ] Code Quality: I have documented my changes thoroughly (using [JSDoc][jsdoc] in Javascript)
- [ ] Process: I have linked relevant issues, [marking issues][gh-marking-issues] that this PR resolves
- [x] Process: I have requested at least as many reviews required for this PR type (2 or 3)
- [x] Process: I have added this PR to the relevant quarterly milestone
- [ ] Process: I have tested this PR locally and verified it does what it should

## How This Has Been Tested
The commented out migration worked on prod, so I assume this should work.




[contrib-guide]: CONTRIBUTING.md
[contrib-guide-prs]: CONTRIBUTING.md#creating-pull-requests
[contrib-guide-deploying]: CONTRIBUTING.md#deploying-carpe
[gh-marking-issues]: https://help.github.com/articles/closing-issues-using-keywords/
[carpe-test]: https://carpe-test.herokuapp.com/
[jsdoc]: http://usejsdoc.org/about-getting-started.html
